### PR TITLE
Add responsive hamburger navigation

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -59,6 +59,21 @@ body {
     color: #ffd93d;
 }
 
+/* Hamburger Menu */
+.hamburger {
+    display: none;
+    flex-direction: column;
+    cursor: pointer;
+    gap: 5px;
+}
+
+.bar {
+    height: 3px;
+    width: 25px;
+    background-color: #fff;
+    transition: all 0.3s ease;
+}
+
 /* Hero Section */
 .hero {
     min-height: 100vh;
@@ -746,5 +761,23 @@ body {
     }
     .nav-container {
         padding: 0 1rem;
+    }
+    .nav-menu {
+        position: fixed;
+        top: 70px;
+        right: -100%;
+        flex-direction: column;
+        gap: 1rem;
+        background: rgba(255, 255, 255, 0.9);
+        width: 100%;
+        text-align: center;
+        transition: right 0.3s ease;
+        padding: 1rem 0;
+    }
+    .nav-menu.active {
+        right: 0;
+    }
+    .hamburger {
+        display: flex;
     }
 }

--- a/styles_sky_theme.css
+++ b/styles_sky_theme.css
@@ -106,6 +106,21 @@ body::before {
     transform: translateY(-2px);
 }
 
+/* Hamburger Menu */
+.hamburger {
+    display: none;
+    flex-direction: column;
+    cursor: pointer;
+    gap: 5px;
+}
+
+.bar {
+    height: 3px;
+    width: 25px;
+    background-color: var(--sky-blue-dark);
+    transition: all 0.3s ease;
+}
+
 /* Hero Section - Sky Theme */
 .hero {
     min-height: 100vh;
@@ -499,8 +514,24 @@ body::before {
     }
     
     .nav-menu {
+        position: fixed;
+        top: 70px;
+        right: -100%;
         flex-direction: column;
         gap: 1rem;
+        background: rgba(255, 255, 255, 0.9);
+        width: 100%;
+        text-align: center;
+        transition: right 0.3s ease;
+        padding: 1rem 0;
+    }
+
+    .nav-menu.active {
+        right: 0;
+    }
+
+    .hamburger {
+        display: flex;
     }
     
     .features {


### PR DESCRIPTION
## Summary
- style hamburger icon and mobile nav for base and sky themes
- collapse navigation into slide-in menu on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae28920d90832cbb1f40e912f958f1