### PR TITLE
Add decorative art elements to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,15 @@
         <div class="paint-splatter" style="top: 15%; left: 60%;"></div>
         <div class="paint-splatter" style="top: 75%; left: 20%;"></div>
         <div class="paint-splatter" style="top: 85%; left: 50%;"></div>
+        <div class="paint-splatter" style="top: 35%; left: 70%;"></div>
+        <div class="paint-splatter" style="top: 10%; left: 30%;"></div>
+        <div class="paint-splatter" style="top: 55%; left: 55%;"></div>
+        <div class="paint-splatter" style="top: 90%; left: 90%;"></div>
+        <!-- Art tool icons -->
+        <i class="fas fa-pencil-alt decor-icon pencil" style="top: 5%; left: 75%;"></i>
+        <i class="fas fa-paint-brush decor-icon brush" style="top: 70%; left: 5%;"></i>
+        <i class="fas fa-pen-nib decor-icon pen" style="top: 50%; left: 90%;"></i>
+        <i class="fas fa-palette decor-icon palette" style="top: 20%; left: 20%;"></i>
     </section>
 
     <!-- About Section -->

--- a/styles_sky_theme.css
+++ b/styles_sky_theme.css
@@ -8,6 +8,7 @@
     --paint-red: #FF4444;
     --paint-yellow: #FFD700;
     --paint-green: #32CD32;
+    --paint-blue: #1E90FF;
     --paint-purple: #9370DB;
     --paint-orange: #FF8C00;
     --brush-brown: #8B4513;
@@ -583,6 +584,40 @@ body {
     background: var(--paint-orange);
     animation-delay: -5s;
 }
+
+.paint-splatter:nth-child(8) {
+    background: var(--paint-red);
+    animation-delay: -6s;
+}
+
+.paint-splatter:nth-child(9) {
+    background: var(--paint-yellow);
+    animation-delay: -2.5s;
+}
+
+.paint-splatter:nth-child(10) {
+    background: var(--paint-blue);
+    animation-delay: -4.5s;
+}
+
+.paint-splatter:nth-child(11) {
+    background: var(--paint-green);
+    animation-delay: -1.5s;
+}
+
+/* Floating Art Icons */
+.decor-icon {
+    position: absolute;
+    font-size: 2rem;
+    opacity: 0.8;
+    animation: float 6s ease-in-out infinite;
+    pointer-events: none;
+}
+
+.decor-icon.pencil { color: var(--paint-yellow); }
+.decor-icon.brush { color: var(--paint-purple); }
+.decor-icon.pen { color: var(--paint-green); }
+.decor-icon.palette { color: var(--paint-orange); }
 
 @keyframes float {
     0%, 100% { transform: translateY(0px) rotate(0deg); }


### PR DESCRIPTION
## Summary
- enrich hero section with additional paint splatters and art tool icons
- support new floating icons and extra splatters in sky theme CSS

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68ae2f093328832c8ddd1a318f995721